### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/AirwaySegmentation/AirwaySegmentation.py
+++ b/AirwaySegmentation/AirwaySegmentation.py
@@ -68,7 +68,6 @@ class AirwaySegmentationWidget:
     #
     self.inputSelector = slicer.qMRMLNodeComboBox()
     self.inputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.inputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.inputSelector.selectNodeUponCreation = True
     self.inputSelector.addEnabled = False
     self.inputSelector.removeEnabled = True
@@ -158,9 +157,8 @@ class AirwaySegmentationWidget:
     self.applyButton.enabled = False
     #self.bronchoscopyButton.enabled = False
             
-    nodeType = 'vtkMRMLScalarVolumeNode'
+    nodeType = 'vtkMRMLLabelMapVolumeNode'
     self.labelNode = slicer.mrmlScene.CreateNodeByClass(nodeType)
-    self.labelNode.SetLabelMap(1)
     self.labelNode.SetScene(slicer.mrmlScene)
     self.labelNode.SetName(slicer.mrmlScene.GetUniqueNameByString('AirwayLabel'))
     slicer.mrmlScene.AddNode(self.labelNode)


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.